### PR TITLE
chore: Change action to Actions-R-Us/actions-tagger

### DIFF
--- a/.github/workflows/update-major-version-tag.yml
+++ b/.github/workflows/update-major-version-tag.yml
@@ -10,4 +10,4 @@ jobs:
     name: Update Major Version Tag
     runs-on: ubuntu-latest
     steps:
-      - uses: nowactions/update-majorver@v1
+      - uses: Actions-R-Us/actions-tagger@v2


### PR DESCRIPTION
The previously used action seems to be abandonded and is not updated to use Node 16.